### PR TITLE
support regional AAD endpoint on public cloud

### DIFF
--- a/sdk/environments/azure_public.go
+++ b/sdk/environments/azure_public.go
@@ -3,10 +3,22 @@
 
 package environments
 
+import (
+	"fmt"
+	"os"
+)
+
 const AzurePublicCloud = "Public"
+const AzureRegionalAuthorityName = "AZURE_REGIONAL_AUTHORITY_NAME"
+const AzurePublicLoginEndpointWithRegion = "https://%s.login.microsoft.com"
 
 func AzurePublic() *Environment {
 	env := baseEnvironmentWithName(AzurePublicCloud)
+
+	loginEndpoint := "https://login.microsoftonline.com"
+	if authorityRegion := os.Getenv(AzureRegionalAuthorityName); authorityRegion != "" {
+		loginEndpoint = fmt.Sprintf(AzurePublicLoginEndpointWithRegion, authorityRegion)
+	}
 
 	env.Authorization = &Authorization{
 		Audiences: []string{
@@ -14,7 +26,7 @@ func AzurePublic() *Environment {
 			"https://management.azure.com",
 		},
 		IdentityProvider: "AAD",
-		LoginEndpoint:    "https://login.microsoftonline.com",
+		LoginEndpoint:    loginEndpoint,
 		Tenant:           "common",
 	}
 	env.ResourceManager = ResourceManagerAPI("https://management.azure.com")


### PR DESCRIPTION
read the environment variable `AZURE_REGIONAL_AUTHORITY_NAME` to setup regional AAD endpoint.
to keep consistent with https://github.com/Azure/azure-sdk-for-go/blob/9cf299f30940e1e90ae6ad0fed177b8ef37046d7/sdk/azidentity/confidential_client.go#L75